### PR TITLE
Bug Fix: Fix regex to remove spaces around periods

### DIFF
--- a/src/explainability/explainability.py
+++ b/src/explainability/explainability.py
@@ -70,9 +70,10 @@ class FixedVocabTokenizer(PreTrainedTokenizer):
         self.mask_token_id = self._token_ids.get(self.mask_token, max_id + 5)
 
     def _tokenize(self, text: str, **kwargs):
-        # Remove spaces beside commas and colons, except within words
-        # (This is done because the transformers-interpret package automatically adds spaces between tokens)
-        text = re.sub(r"\s*([:,])\s*", r"\1", text)
+        # Remove spaces comma (,) colon (:) period (.) hyphen (-) and slash (/) except within words
+        # (This is done because the transformers-interpret package
+        # automatically adds spaces between tokens)
+        text = re.sub(r"\s*([,:.\-/])\s*", r"\1", text)
         tokens = text.split(",")
         return tokens
 


### PR DESCRIPTION
Previously, the regular expression did not remove spaces around periods. This caused issues with ICD-9/10 code formatting, leading to mismatches with the vocabulary (e.g., `"S12.345"` was incorrectly transformed to `"S12 . 345"`).
This PR updates the regex to correctly strip spaces around periods, hyphens, and slashes.